### PR TITLE
[cleaner] Improve output

### DIFF
--- a/pandokia/cleaner.py
+++ b/pandokia/cleaner.py
@@ -203,7 +203,7 @@ def delete_background(argv=[], verbose=False):
 
         if verbose:
             print('{:>{width}d}/{:>{width}d} {:>#06.2f}% '
-                    'TPR={:>#02.2f} ES={:>#08.2f} ESR={:>#08.2f}'.format(
+                    'time_per_record={:>#02.2f} time_elapsed={:>#08.2f} time_remaining={:>#08.2f}'.format(
                       total_deleted, total_records, percent_remaining,
                       time_per_record, time_so_far, time_remaining,
                       width=len(str(total_records))))


### PR DESCRIPTION
Since we're hooking this aspect of pandokia up to a bi-weekly cronjob I'm trying to avoid receiving gigantic emails with redundant information. That is, there's no need for a progress indicator while running as a background process.

The `delete_background` method is the entry-point for `pdk clean`, and the inline argument parsing did not (gracefully) allow for expansion so it was replaced by `argparse`. I honestly do not foresee ever running pandokia below Python 2.7, so this shouldn't present a problem.