### PR TITLE
Normalize python shebangs

### DIFF
--- a/commands/junittopdk
+++ b/commands/junittopdk
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 """junittopdk [options] FILES | pdk import -
 
 Convert junix/xml files into pandokia format.  This is an experimental

--- a/commands/pdk
+++ b/commands/pdk
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 
 #
 # pandokia - a test reporting and execution system

--- a/commands/pdk_filecomp
+++ b/commands/pdk_filecomp
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python
 
 #
 # pandokia - a test reporting and execution system

--- a/commands/pdk_stsci_regress_helper
+++ b/commands/pdk_stsci_regress_helper
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 
 #
 # pandokia - a test reporting and execution system

--- a/commands/pdk_stsci_regress_refs
+++ b/commands/pdk_stsci_regress_refs
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 
 #
 # pandokia - a test reporting and execution system

--- a/commands/pdknose
+++ b/commands/pdknose
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 
 #
 # pandokia - a test reporting and execution system

--- a/commands/pdkpytest
+++ b/commands/pdkpytest
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 
 #
 # pandokia - a test reporting and execution system

--- a/commands/pdkrun
+++ b/commands/pdkrun
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 
 #
 # pandokia - a test reporting and execution system

--- a/pandokia/env_platforms.py
+++ b/pandokia/env_platforms.py
@@ -1,4 +1,4 @@
-#! /bin/env python
+#!/usr/bin/env python
 """This module contains mappings to construct platform-specific
 identifying information that will be used by the EnvGetter to apply
 the appoprirate specific subsections of the pdk_environment files.

--- a/pandokia/helpers/runner_minipyt.py
+++ b/pandokia/helpers/runner_minipyt.py
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 #
 
 import sys

--- a/pandokia/run.py
+++ b/pandokia/run.py
@@ -1,4 +1,4 @@
-#!/usr/stsci/pyssgdev/Python-2.5.1/bin/python
+#!/usr/bin/env python
 import sys
 import getopt
 import os

--- a/test_new/config
+++ b/test_new/config
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python
 import os
 
 cfg = {


### PR DESCRIPTION
They pointed to various non-standard places or no places at all (`#! python`)