### PR TITLE
Change environment exception to warning

### DIFF
--- a/pandokia/envgetter.py
+++ b/pandokia/envgetter.py
@@ -32,6 +32,7 @@ go all the way to the top of the file system.
 import os
 import sys
 import re
+import warnings
 
 try:
     import ConfigParser as configparser
@@ -328,11 +329,11 @@ class EnvGetter(object):
         # Check for missing values.
 
         if len(self.nodes[dirname].missing) > 0:
-            raise KeyError(
+            warnings.warn(
                 "Missing values for %s. A complete environment cannot be provided for %s." %
-                (self.nodes[dirname].missing, dirname))
-        else:
-            return self.nodes[dirname].final
+                (self.nodes[dirname].missing, dirname)
+            )
+        return self.nodes[dirname].final
 
     def gettop(self):
         """Return remembered "top" of environment.


### PR DESCRIPTION
If `Envgetter` is unable to provide a "complete environment",
apparently based on environmental variables, an exception is raised
and testing stops. However, most of these issues arise from deep
diving into bash functions and other oddities. The vars that the
script are worried about are normal vars and will be replicable.

Hence, changing the `Exception` to a `warnings.warn` so the user is
aware of the situation and be able to, if necessary, debug later
issues in a test. However, the testing will at least proceed.